### PR TITLE
refactor: make min_score parameter optional

### DIFF
--- a/pharia_skill/csi.py
+++ b/pharia_skill/csi.py
@@ -230,6 +230,6 @@ class WasiCsi(Csi):
         index_path: IndexPath,
         query: str,
         max_results: int,
-        min_score: float | None,
+        min_score: float | None = None,
     ) -> list[SearchResult]:
         return csi.search(index_path, query, max_results, min_score)


### PR DESCRIPTION
update the search method in WasiCsi to make the min_score parameter optional by assigning it a default value of None.