### PR TITLE
refactor: replace RootModel with typed classes

### DIFF
--- a/examples/failing.py
+++ b/examples/failing.py
@@ -6,8 +6,13 @@ from pydantic import RootModel
 
 from pharia_skill import Csi, skill
 
-Input = RootModel[str]
-Output = RootModel[str]
+
+class Input(RootModel):
+    root: str
+
+
+class Output(RootModel):
+    root: str
 
 
 @skill

--- a/examples/failing_test.py
+++ b/examples/failing_test.py
@@ -6,7 +6,7 @@ from .failing import Input, failing
 
 
 def test_skill_raises():
-    input = Input("Oat milk")
+    input = Input(root="Oat milk")
     csi = StubCsi()
     with pytest.raises(ValueError):
         failing(csi, input)

--- a/examples/haiku.py
+++ b/examples/haiku.py
@@ -6,7 +6,9 @@ from pydantic import BaseModel, RootModel
 
 from pharia_skill import ChatParams, CompletionParams, Csi, Message, skill
 
-Input = RootModel[str]
+
+class Input(RootModel):
+    root: str
 
 
 class Output(BaseModel):

--- a/examples/haiku_test.py
+++ b/examples/haiku_test.py
@@ -8,7 +8,7 @@ from .haiku import Input, Output, haiku
 
 
 def test_haiku():
-    input = Input("oat milk")
+    input = Input(root="oat milk")
     result = haiku(StubCsi(), input)
     assert isinstance(result, Output)
     assert "oat milk" in result.completion

--- a/examples/summarize.py
+++ b/examples/summarize.py
@@ -28,7 +28,9 @@ class Input(BaseModel):
     language: Language | None = None
 
 
-Output = RootModel[str]
+class Output(RootModel):
+    root: str
+
 
 # English and German prompts for different intended summary lengths.
 SUMMARIZATION_PROMPTS = {
@@ -104,4 +106,4 @@ def summarize(csi: Csi, input: Input) -> Output:
         if last_no_summaries and len(summaries) == last_no_summaries:
             break
         last_no_summaries = len(summaries)
-    return Output(text)
+    return Output(root=text)


### PR DESCRIPTION
Replace type hints with explicit Pydantic models for Input and Output in examples.