### PR TITLE
docs: add link to SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 You build your skill in Python, which is then compiled into a Wasm module. Then, the skill is deployed to Pharia Kernel, where it can be invoked on demand. To this end, this SDK provides some tooling and APIs for skill development.
 
+You can access the [Documentation](https://aleph-alpha-pharia-kernel-sdk-py.readthedocs-hosted.com/en/latest/index.html)
+with your GitHub account.
+
 ## Installing SDK
 
 The SDK is distributed via the Aleph Alpha Artifactory PyPI. You may need to request a JFrog account, or extend the permission of your JFrog account via the [Product Service Desk](https://aleph-alpha.atlassian.net/servicedesk/customer/portals).


### PR DESCRIPTION
Add link to SDK documentation and clarify access requirements. Update README to include information on accessing the documentation with a GitHub account.