### PR TITLE
refactor: add input validation to CLI commands

### DIFF
--- a/pharia_skill/cli.py
+++ b/pharia_skill/cli.py
@@ -43,6 +43,11 @@ def run_componentize_py(skill_module: str):
     The call to componentize-py targets the `skill` wit world and adds the downloaded
     Pydantic WASI wheels to the Python path.
     """
+    if "/" in skill_module or skill_module.endswith(".py"):
+        logger.error(
+            f"argument must be fully qualified python module name, not {skill_module}"
+        )
+        return
     output_file = f"./{skill_module.split('.')[-1]}.wasm"
     command = [
         "componentize-py",
@@ -57,18 +62,8 @@ def run_componentize_py(skill_module: str):
         "-p",
         "wasi_deps",
     ]
+    logger.info(f"Building WASM component {output_file} from {skill_module} ...")
     subprocess.run(command, check=True)
-
-
-def image_exists(image_name: str) -> bool:
-    """Check if a given podman image exists locally."""
-    result = subprocess.run(
-        ["podman", "images", "--format", "{{.Repository}}:{{.Tag}}"],
-        stdout=subprocess.PIPE,
-        text=True,
-    )
-
-    return image_name in result.stdout
 
 
 def main():

--- a/pharia_skill/pharia_skill_cli.py
+++ b/pharia_skill/pharia_skill_cli.py
@@ -121,6 +121,12 @@ class PhariaSkillCli:
         if not skill.startswith(("/", "./")):
             skill = f"./{skill}"
 
+        if not os.path.exists(skill):
+            logger.error(f"No such file: {skill}")
+            return
+        logger.info(
+            f"Publishing skill file {skill} to\n{skill_registry}/{skill_repository} ..."
+        )
         command = [
             self.PHARIA_SKILL_CLI_PATH,
             "publish",


### PR DESCRIPTION
Validate skill module name and path in cli.py and add error handling for non-existent skill files in pharia_skill_cli.py.