### PR TITLE
feat: enable adding additional source paths

### DIFF
--- a/pharia_skill/cli.py
+++ b/pharia_skill/cli.py
@@ -114,7 +114,7 @@ def run_componentize_py(
     output_file: str,
     unstable: bool,
     skill_type: SkillType,
-    source_paths: list[str] | None = None,
+    source_paths: list[str],
 ) -> str:
     """Build the skill to a Wasm component using componentize-py.
 
@@ -139,9 +139,8 @@ def run_componentize_py(
         "-p",
         "wasi_deps",
     ]
-    if source_paths is not None:
-        for source_path in source_paths:
-            command.extend(["-p", source_path])
+    for source_path in source_paths:
+        command.extend(["-p", source_path])
 
     try:
         subprocess.run(
@@ -362,7 +361,7 @@ def build(
         task = progress.add_task("", total=None)
         try:
             wasm_file = run_componentize_py(
-                skill, output_file, unstable, skill_type, source_paths
+                skill, output_file, unstable, skill_type, source_paths or []
             )
             progress.update(task, completed=True)
         except IsMessageStream:

--- a/pharia_skill/cli.py
+++ b/pharia_skill/cli.py
@@ -110,7 +110,11 @@ class SkillType(str, Enum):
 
 
 def run_componentize_py(
-    skill_module: str, output_file: str, unstable: bool, skill_type: SkillType
+    skill_module: str,
+    output_file: str,
+    unstable: bool,
+    skill_type: SkillType,
+    source_paths: list[str] | None = None,
 ) -> str:
     """Build the skill to a Wasm component using componentize-py.
 
@@ -135,6 +139,9 @@ def run_componentize_py(
         "-p",
         "wasi_deps",
     ]
+    if source_paths is not None:
+        for source_path in source_paths:
+            command.extend(["-p", source_path])
 
     try:
         subprocess.run(
@@ -306,6 +313,15 @@ def build(
             show_default=True,
         ),
     ] = SkillType.SKILL,
+    source_paths: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--source-path",
+            "-p",
+            help="Additional source paths to include in the build.",
+            show_default=False,
+        ),
+    ] = None,
 ) -> None:
     """
     [bold blue]Build[/bold blue] a skill.
@@ -345,7 +361,9 @@ def build(
     ) as progress:
         task = progress.add_task("", total=None)
         try:
-            wasm_file = run_componentize_py(skill, output_file, unstable, skill_type)
+            wasm_file = run_componentize_py(
+                skill, output_file, unstable, skill_type, source_paths
+            )
             progress.update(task, completed=True)
         except IsMessageStream:
             console.print(

--- a/tests/pharia_skill_cli_test.py
+++ b/tests/pharia_skill_cli_test.py
@@ -22,6 +22,7 @@ def test_building_message_stream_skill_with_wrong_skill_type_raises():
             "haiku_stream.wasm",
             False,
             SkillType.SKILL,
+            [],
         )
 
 
@@ -32,6 +33,7 @@ def test_building_skill_with_wrong_skill_type_raises():
             "haiku.wasm",
             False,
             SkillType.MESSAGE_STREAM_SKILL,
+            [],
         )
 
 
@@ -42,4 +44,5 @@ def test_building_skill_which_imports_requests_raises():
             "http_haiku.wasm",
             False,
             SkillType.SKILL,
+            [],
         )


### PR DESCRIPTION
For creance we needed to build with additional source paths (in our case just the `src` directory of our repository) and quickly adapted the cli.py locally. The proposed solution worked for us. Other teams might find this useful as well as the setup with a `src` folder is quite common for pyhton projects, so I figured I could quickly suggest this pull request.