### PR TITLE
feat: use pydantic's built in json serialization instead of json.dumps

### DIFF
--- a/pharia_skill/skill.py
+++ b/pharia_skill/skill.py
@@ -113,9 +113,9 @@ def skill(
         from opentelemetry import trace
 
         with trace.get_tracer(__name__).start_as_current_span(func.__name__) as span:
-            span.set_attribute("input", json.dumps(input.model_dump()))
+            span.set_attribute("input", input.model_dump_json())
             result = func(csi, input)
-            span.set_attribute("output", json.dumps(result.model_dump()))
+            span.set_attribute("output", result.model_dump_json())
             return result
 
     func.__globals__["SkillHandler"] = SkillHandler


### PR DESCRIPTION
Note: The issue is only about the _tracing_ of a skill. The skill itself can already handle serialization of UUIDs etc using pydantics json (de)serialization.

This Commit enables serialization of more complex but still handled datatypes like datetimes and UUIDs also while tracing the skill execution.