### PR TITLE
feat: add message helper method to ChatStreamResponse

### DIFF
--- a/pharia_skill/csi/inference/inference.py
+++ b/pharia_skill/csi/inference/inference.py
@@ -24,6 +24,7 @@ from .types import (
     Message,
     MessageAppend,
     MessageBegin,
+    Role,
     TokenUsage,
 )
 
@@ -319,6 +320,31 @@ class ChatStreamResponse(ABC):
                 case TokenUsage():
                     self._usage = event
                     break
+
+    def message(self) -> Message:
+        """A helper method to get the content of the message.
+
+        This method consumes the stream and can only be used as long as the stream is
+        not consumed. It can be useful for testing purposes, where you are interested
+        in the content of the message. If the stream has already been consumed, an empty
+        message is returned.
+
+        Example::
+
+            def test_my_prompt():
+                user = Message.user("What is the meaning of life?")
+                with csi.chat_stream("llama-3.1-8b-instruct", [user]) as response:
+                    message = response.message()
+
+                assert message.content == "42"
+
+        Returns:
+            The message of the chat request.
+        """
+        content = ""
+        for event in self.stream():
+            content += event.content
+        return Message(role=Role(self.role), content=content)
 
 
 @dataclass

--- a/pharia_skill/csi/inference/inference.py
+++ b/pharia_skill/csi/inference/inference.py
@@ -322,11 +322,12 @@ class ChatStreamResponse(ABC):
                     break
 
     def consume_message(self) -> Message:
-        """A helper method to get the content of the message.
+        """A helper method that extracts the contained message from a chat stream.
 
-        This method consumes the stream and can only be used as long as the stream is
-        not consumed. It can be useful for testing purposes, where you are interested
-        in the content of the message. If the stream has already been consumed, an empty
+        This method consumes the stream and only returns the entire messages as long as
+        the stream has not been consumed. It can be useful for testing purposes, where
+        you are interested in the content of the entire message and not in the
+        individual events. In case the stream has already been consumed, an empty
         message is returned.
 
         Example::

--- a/pharia_skill/csi/inference/inference.py
+++ b/pharia_skill/csi/inference/inference.py
@@ -321,7 +321,7 @@ class ChatStreamResponse(ABC):
                     self._usage = event
                     break
 
-    def message(self) -> Message:
+    def consume_message(self) -> Message:
         """A helper method to get the content of the message.
 
         This method consumes the stream and can only be used as long as the stream is
@@ -334,7 +334,7 @@ class ChatStreamResponse(ABC):
             def test_my_prompt():
                 user = Message.user("What is the meaning of life?")
                 with csi.chat_stream("llama-3.1-8b-instruct", [user]) as response:
-                    message = response.message()
+                    message = response.consume_message()
 
                 assert message.content == "42"
 

--- a/tests/csi/inference_test.py
+++ b/tests/csi/inference_test.py
@@ -134,7 +134,7 @@ def test_message_helper():
     response = MockChatStreamResponse(events)
 
     # When using the message helper
-    message = response.message()
+    message = response.consume_message()
 
     # Then it should return the message
     assert message.role == Role.Assistant
@@ -152,7 +152,7 @@ def test_message_helper_after_stream_is_consumed():
 
     # When consuming the stream and then using the message helper
     list(response.stream())
-    message = response.message()
+    message = response.consume_message()
 
     # Then no error is raised, but an empty message is returned
     assert message.role == Role.Assistant

--- a/tests/csi/inference_test.py
+++ b/tests/csi/inference_test.py
@@ -122,3 +122,38 @@ def test_peeking_at_event_does_not_alter_stream():
         MessageAppend(content="Hello, ", logprobs=[]),
         MessageAppend(content="world!", logprobs=[]),
     ]
+
+
+def test_message_helper():
+    # Given a chat stream response that returns multiple events
+    events: list[ChatEvent] = [
+        MessageBegin(role="assistant"),
+        MessageAppend(content="Hello, ", logprobs=[]),
+        MessageAppend(content="world!", logprobs=[]),
+    ]
+    response = MockChatStreamResponse(events)
+
+    # When using the message helper
+    message = response.message()
+
+    # Then it should return the message
+    assert message.role == Role.Assistant
+    assert message.content == "Hello, world!"
+
+
+def test_message_helper_after_stream_is_consumed():
+    # Given a chat stream response that returns multiple events
+    events: list[ChatEvent] = [
+        MessageBegin(role="assistant"),
+        MessageAppend(content="Hello, ", logprobs=[]),
+        MessageAppend(content="world!", logprobs=[]),
+    ]
+    response = MockChatStreamResponse(events)
+
+    # When consuming the stream and then using the message helper
+    list(response.stream())
+    message = response.message()
+
+    # Then no error is raised, but an empty message is returned
+    assert message.role == Role.Assistant
+    assert message.content == ""


### PR DESCRIPTION
without these methods, a writer would need to be constructed
to reconstruct the message, which makes writing tests more complicated
