### PR TITLE
test: replace pharia-1-llm-7b-control by llama-3.1-8b-instruct

### DIFF
--- a/examples/rag.py
+++ b/examples/rag.py
@@ -33,5 +33,5 @@ Question: {input.question}
 """
     message = Message.user(content)
     params = ChatParams(max_tokens=512)
-    response: ChatResponse = csi.chat("pharia-1-llm-7b-control", [message], params)
+    response: ChatResponse = csi.chat("llama-3.1-8b-instruct", [message], params)
     return Output(answer=response.message.content, number_of_documents=len(documents))

--- a/tests/skills/rechunk_test.py
+++ b/tests/skills/rechunk_test.py
@@ -61,7 +61,7 @@ def rechunk(csi: Csi, input: Input) -> Output:
     assert isinstance(content, Text)
 
     # expand
-    params = ChunkParams(model="pharia-1-llm-7b-control", max_tokens=20, overlap=0)
+    params = ChunkParams(model="llama-3.1-8b-instruct", max_tokens=20, overlap=0)
     chunks = csi.chunk(content.text, params)
 
     # filter

--- a/tests/skills/text_highlighting_test.py
+++ b/tests/skills/text_highlighting_test.py
@@ -266,7 +266,7 @@ Answer:
     input = Input(
         prompt=prompt,
         raw_completion="The ecosystem is adapted to extreme conditions.",
-        model="pharia-1-llm-7b-control",
+        model="llama-3.1-8b-instruct",
         source_ranges=[(54, 624), (635, 1100)],
     )
     csi = DevCsi()


### PR DESCRIPTION
it seems that pharia-1-llm is not always available on prod instances, and reducing
the number of models needed to run the tests appears to be sensible
